### PR TITLE
Add DIY 100% category support to III and VC autosplitters

### DIFF
--- a/LiveSplit.GTA3.asl
+++ b/LiveSplit.GTA3.asl
@@ -419,7 +419,7 @@ update
 			vars.taxiWatcher.Update(game);
 			if (vars.taxiWatcher.Current == 1)
 			{
-				if ((current.percentage/1.54) > vars.percentageOld)
+				if ((current.percentage/1.54) > vars.percentageOld && (current.percentage/1.54) < 100.0)
 				{
 					vars.hundoShouldSplit = true;
 					vars.percentageOld = current.percentage/1.54;

--- a/LiveSplit.GTA3.asl
+++ b/LiveSplit.GTA3.asl
@@ -346,7 +346,7 @@ update
 			vars.percentageOld = current.percentage/1.54;
 		}
 		
-		// NG+ 100% section for Gael
+		// NG+ 100% section for Gael. After reaching first taxi dupe, it splits for every percentage change.
 		if (vars.category.Contains("NG+"))
 		{
 			vars.taxiWatcher.Update(game);

--- a/LiveSplit.GTA3.asl
+++ b/LiveSplit.GTA3.asl
@@ -416,15 +416,15 @@ update
 		// NG+ 100% section for Gael. After reaching first taxi dupe, it splits for every percentage change.
 		if (vars.category.Contains("ng"))
 		{
-			vars.taxiWatcher.Update(game);
-			if (vars.taxiWatcher.Current == 1)
-			{
+			//vars.taxiWatcher.Update(game);
+			//if (vars.taxiWatcher.Current == 1)
+			//{
 				if ((current.percentage/1.54) > vars.percentageOld && (current.percentage/1.54) < 100.0)
 				{
 					vars.hundoShouldSplit = true;
 					vars.percentageOld = current.percentage/1.54;
 				}
-			}
+			//}
 		}
 		
 		// If you want to split independently of mission, make your checks outside this switch block.

--- a/LiveSplit.GTA3.asl
+++ b/LiveSplit.GTA3.asl
@@ -206,6 +206,10 @@ init
 			// TODO: add misc addresses
 		}
 		
+		///////////////////// C O L L E C T A B L E S /////////////////////
+		else if (vars.category.Contains("package") || vars.category.Contains("stunt") ||
+			vars.category.Contains("jump") || vars.category.Contains("rampage")) {}
+		
 		///////////////////////////////////////////////////////////////////
 		else 
 		{
@@ -260,6 +264,49 @@ init
 	
 	// Used to know what state the game is currently in.
 	vars.gameState = new MemoryWatcher<int>(new DeepPointer(0x505A2C+vars.offset));
+	
+	// Init section for collectable runs. [nice conditions]
+	// For "simplicity" reasons, mixed runs (for example: packages + stunts) are not supported.
+	// Nobody does it anyway, but in case someone attempts it, the first category will override any other.
+	// Interesting thing is "mission type" and "collectable type" run mix will actually work.
+	else if (vars.category.Contains("package") || vars.category.Contains("stunt") ||
+			vars.category.Contains("jump") || vars.category.Contains("rampage"))
+	{
+		vars.collectableIndex = 0;
+		
+		// You can specify when autosplitter splits by adding values (separated by commas)
+		// IN ASCENDING ORDER to vars.collectableSplitOn arrays.
+		
+		////////////// 1 0 0   H I D D E N   P A C K A G E S //////////////
+		if (vars.category.Contains("package"))
+		{
+			// Set up memory watcher for collected packages counter
+			vars.collectable = new MemoryWatcher<int>(new DeepPointer(0x35C3D4+vars.offset));
+			
+			// By default it splits on 100 packages (max value)
+			vars.collectableSplitOn = new int[] { 100 };
+		}
+		
+		/////////// A L L   U N I Q U E   S T U N T   J U M P S ///////////
+		else if (vars.category.Contains("stunt") || vars.category.Contains("jump"))
+		{
+			// Set up memory watcher for completed USJs counter
+			vars.collectable = new MemoryWatcher<int>(new DeepPointer(0x35BFB0+vars.offset));
+			
+			// By default it splits on 20 USJs (max value)
+			vars.collectableSplitOn = new int[] { 20 };
+		}
+		
+		///////////////////// A L L   R A M P A G E S /////////////////////
+		else if (vars.category.Contains("rampage"))
+		{
+			// Set up memory watcher for completed rampages counter
+			vars.collectable = new MemoryWatcher<int>(new DeepPointer(0x35C0AC+vars.offset));
+			
+			// By default it splits on 20 rampages (max value)
+			vars.collectableSplitOn = new int[] { 20 };
+		}
+	}
 	
 	// Second part of 100% run stuff
 	if (vars.category.Contains("100%") || vars.category.Contains("hundo")) 
@@ -332,6 +379,23 @@ update
 		if (current.exchangeHelipad == 1 && current.exchangeTimer != vars.exchangeTimerOld) {vars.doSplit = true;}
 		vars.exchangeTimerOld = current.exchangeTimer;
 	}
+	// Collectables
+	else if (vars.category.Contains("package") || vars.category.Contains("stunt") ||
+			vars.category.Contains("jump") || vars.category.Contains("rampage"))
+	{
+		vars.collectable.Update(game);
+		
+		// Split when number of required collectables for next split equals the one ingame.
+		if (vars.collectable.Old < vars.collectableSplitOn[vars.collectableIndex] && vars.collectable.Current == vars.collectableSplitOn[vars.collectableIndex])
+		{
+			vars.doSplit = true;
+			
+			if (vars.collectableIndex < vars.collectableSplitOn.Length-1)
+			{
+				vars.collectableIndex++;
+			}
+		}
+	}
 	// 100%
 	// For now it only splits when ingame percentage reaches 100%
 	// It's possible to add optional checks for splits for all kinds of fancy crap in the game
@@ -391,6 +455,11 @@ start
 		if (vars.missionAddressesCurrent.Count != 0) {
 			vars.currentMissionWatcher = new MemoryWatcher<byte>(new DeepPointer(vars.missionAddressesCurrent[0]+vars.offset));
 			vars.checkCurrentMission = false;
+		}
+		if (vars.category.Contains("package") || vars.category.Contains("stunt") ||
+			vars.category.Contains("jump") || vars.category.Contains("rampage"))
+		{
+			vars.collectableIndex = 0;
 		}
 		if (vars.category.Contains("100%") || vars.category.Contains("hundo"))
 		{

--- a/LiveSplit.GTA3.asl
+++ b/LiveSplit.GTA3.asl
@@ -470,7 +470,7 @@ start
 		else if (vars.category.Contains("100%") || vars.category.Contains("hundo"))
 		{
 			vars.percentageOld = 0.0;
-			vars.hundoCompletedMission = vars.missionAddressesCurrent[0];
+			if (vars.missionAddressesCurrent.Count != 0) {vars.hundoCompletedMission = vars.missionAddressesCurrent[0];}
 		}
 	}
 	

--- a/LiveSplit.GTA3.asl
+++ b/LiveSplit.GTA3.asl
@@ -336,9 +336,7 @@ update
 	// For now it only splits when ingame percentage reaches 100%
 	// It's possible to add optional checks for splits for all kinds of fancy crap in the game
 	if (vars.category.Contains("100%") || vars.category.Contains("hundo")) 
-	{
-		vars.hundoPackage.Update(game);
-		
+	{		
 		// Divide by 1.54 because there are 154 places in script that "add" percentage. Well coded Rockstar, well coded.
 		if ((current.percentage/1.54) >= 100.0 && (current.percentage/1.54) != vars.percentageOld) 
 		{
@@ -347,7 +345,7 @@ update
 		}
 		
 		// NG+ 100% section for Gael. After reaching first taxi dupe, it splits for every percentage change.
-		if (vars.category.Contains("NG+"))
+		if (vars.category.Contains("ng"))
 		{
 			vars.taxiWatcher.Update(game);
 			if (vars.taxiWatcher.Current == 1)
@@ -373,6 +371,7 @@ update
 					vars.hundoMissionDone = false;
 				}
 				break;
+		}
 		
 		if (vars.hundoShouldSplit == true) 
 		{ 

--- a/LiveSplit.GTA3.asl
+++ b/LiveSplit.GTA3.asl
@@ -265,7 +265,26 @@ init
 	// Used to know what state the game is currently in.
 	vars.gameState = new MemoryWatcher<int>(new DeepPointer(0x505A2C+vars.offset));
 	
-	// Init section for collectable runs. [nice conditions]
+	// Init section for 100%
+	if (vars.category.Contains("100%") || vars.category.Contains("hundo")) 
+	{
+		vars.hundoShouldSplit = false;
+		vars.hundoMissionDone = false; // Used to check if buffered mission is done
+		vars.percentageOld = 0.0;
+		if (vars.missionAddressesCurrent.Count != 0)
+		{
+			vars.hundoCompletedMission = vars.missionAddressesCurrent[0]; // Used to store buffered mission
+		}
+		else
+		{
+			vars.hundoCompletedMission = 0x0;
+		}
+		
+		// Watchers
+		vars.taxiWatcher = new MemoryWatcher<byte>(new DeepPointer(0x35B9C4+vars.offset));
+	}
+	
+	// Init section for collectable runs.
 	// For "simplicity" reasons, mixed runs (for example: packages + stunts) are not supported.
 	// Nobody does it anyway, but in case someone attempts it, the first category will override any other.
 	// Interesting thing is "mission type" and "collectable type" run mix will actually work.
@@ -306,23 +325,6 @@ init
 			// By default it splits on 20 rampages (max value)
 			vars.collectableSplitOn = new int[] { 20 };
 		}
-	}
-	
-	// Second part of 100% run stuff
-	if (vars.category.Contains("100%") || vars.category.Contains("hundo")) 
-	{
-		vars.hundoShouldSplit = false;
-		if (vars.missionAddressesCurrent.Count != 0)
-		{
-			vars.hundoCompletedMission = vars.missionAddressesCurrent[0]; // Used to store buffered mission
-		}
-		else
-		{
-			vars.hundoCompletedMission = 0x0;
-		}
-		vars.hundoMissionDone = false; // Used to check if buffered mission is done
-		vars.percentageOld = 0.0;
-		vars.taxiWatcher = new MemoryWatcher<int>(new DeepPointer(0x35B9C4+vars.offset));
 	}
 }
 
@@ -370,6 +372,7 @@ update
 		
 		else {vars.checkCurrentMission = true;}
 	}
+	
 	// Final split for any%
 	// That timer variable is used in different missions so we're making sure that we're on The Exchange
 	// by also checking for variable that is set in the very last part of the mission.
@@ -379,6 +382,7 @@ update
 		if (current.exchangeHelipad == 1 && current.exchangeTimer != vars.exchangeTimerOld) {vars.doSplit = true;}
 		vars.exchangeTimerOld = current.exchangeTimer;
 	}
+	
 	// Collectables
 	else if (vars.category.Contains("package") || vars.category.Contains("stunt") ||
 			vars.category.Contains("jump") || vars.category.Contains("rampage"))
@@ -396,8 +400,9 @@ update
 			}
 		}
 	}
+	
 	// 100%
-	// For now it only splits when ingame percentage reaches 100%
+	// By default it only splits on missions from 100% section of missionAddresses list and when ingame percentage reaches 100%
 	// It's possible to add optional checks for splits for all kinds of fancy crap in the game
 	if (vars.category.Contains("100%") || vars.category.Contains("hundo")) 
 	{		
@@ -424,6 +429,7 @@ update
 		
 		// If you want to split independently of mission, make your checks outside this switch block.
 		// If you need help ping Pitpo on #gta channel on SRL's IRC server.
+		// You can find two examples of using this switch in Vice City autosplitter
 		switch ((int)vars.hundoCompletedMission)
 		{
 			case 0:
@@ -461,7 +467,7 @@ start
 		{
 			vars.collectableIndex = 0;
 		}
-		if (vars.category.Contains("100%") || vars.category.Contains("hundo"))
+		else if (vars.category.Contains("100%") || vars.category.Contains("hundo"))
 		{
 			vars.percentageOld = 0.0;
 			vars.hundoCompletedMission = vars.missionAddressesCurrent[0];

--- a/LiveSplit.GTA3.asl
+++ b/LiveSplit.GTA3.asl
@@ -414,7 +414,7 @@ update
 		}
 		
 		// NG+ 100% section for Gael. After reaching first taxi dupe, it splits for every percentage change.
-		if (vars.category.Contains("ng"))
+		if (vars.category.Contains("ingame") || vars.category.Contains("in-game"))
 		{
 			//vars.taxiWatcher.Update(game);
 			//if (vars.taxiWatcher.Current == 1)

--- a/LiveSplit.GTAVC.asl
+++ b/LiveSplit.GTAVC.asl
@@ -482,7 +482,7 @@ start
 		else if (vars.category.Contains("100%") || vars.category.Contains("hundo"))
 		{
 			vars.percentageOld = 0.0;
-			vars.hundoCompletedMission = vars.missionAddressesCurrent[0];
+			if (vars.missionAddressesCurrent.Count != 0) {vars.hundoCompletedMission = vars.missionAddressesCurrent[0];}
 		}
 	}
 	

--- a/LiveSplit.GTAVC.asl
+++ b/LiveSplit.GTAVC.asl
@@ -259,6 +259,7 @@ init
 		vars.hundoRobberies = new MemoryWatcher<int>(new DeepPointer(0x422A6C+vars.offset));
 		vars.hundoStunts = new MemoryWatcher<int>(new DeepPointer(0x421EDC+vars.offset));
 		
+		vars.KYFCDone = new MemoryWatcher<int>(new DeepPointer(0x4216B8+vars.offset));
 		//vars.paramedicOnMission = new MemoryWatcher<byte>(new DeepPointer(0x421778+vars.offset));
 	}
 	
@@ -411,9 +412,10 @@ update
 		vars.hundoRampages.Update(game);
 		vars.hundoRobberies.Update(game);
 		vars.hundoStunts.Update(game);
+		vars.KYFCDone.Update(game);
 		//vars.paramedicOnMission.Update(game);
 		
-		if (current.percentage >= 100.00 && current.percentage != vars.percentageOld)
+		if (current.percentage >= 100.00 && current.percentage != vars.percentageOld && vars.KYFCDone.Current == 1)
 		{
 			vars.hundoShouldSplit = true;
 			vars.percentageOld = current.percentage;


### PR DESCRIPTION
Some ambitious people may make use of it. Others will have percentage check in case they don't finish with KYFC/Exchange (imports/exports, Gripped, other things that can go wrong and be postponed to the very last part of the run). The only issue i'm aware of is that reaching 'rewarding' code section more than once for any activity will cause a premature final split. For example look at the end of S' 100% VC run. For now I added additional check for KYFC (which makes this whole section kinda useless). I don't know how duping in III works and I don't know if Pete duped in his PB, but it looks like rewarding code isn't triggered twice there(?), so I'm keeping it as it is.  
By the way, I added misc runs support to III.