### PR TITLE
gtav: add support for steam 1365.1

### DIFF
--- a/LiveSplit.GTAV.asl
+++ b/LiveSplit.GTAV.asl
@@ -90,6 +90,11 @@ state("GTA5", "RGSC7912")
 	int loading : 0x22486F0;
 }
 
+state("GTA5", "Steam13651")
+{
+	int loading : 0x2243660;
+}
+
 init
 {
 	switch (modules.First().ModuleMemorySize)
@@ -146,6 +151,9 @@ init
 			break;
 		case 68791808:
 			version = "RGSC7912";
+			break;
+		case 84561920:
+			version = "Steam13651";
 			break;
 	}
 }


### PR DESCRIPTION
Wanted to personally use load removal for GTAO runs, so I decided to find the memory address.

I used https://github.com/drtchops/LiveSplit.GTAV64/issues/1 to find the memory addresses for the latest Steam version, used the hacked GTAV64 Livesplit exe to find the ModuleMemorySize and then cheat engine in game to find the loading memory address. This should stop the timer only on loading, not whenever player doesn't have control. If there are some steps to check if this address is correct, let me know.
Also I have no idea how you define versions, I just used the version from GTAV exe (1.0.1365.1)