### PR TITLE
gta3: add usj, rampage and hidden package splitters

### DIFF
--- a/LiveSplit.GTA3-NEW.asl
+++ b/LiveSplit.GTA3-NEW.asl
@@ -97,6 +97,23 @@ startup
 		vars.missionList.Add(address.Value);
 	}
 	
+	
+	// Collectibles
+	vars.collectibleAddresses = new Dictionary<int, string> {
+		{0x35C3D4,"Hidden Packages"},
+		{0x35C0AC,"Rampages"},
+		{0x35BFB0,"Unique Stunt Jumps"}
+	};
+	
+	settings.Add("Collectibles", false, "Collectibles");
+	
+	vars.collectList = new List<string>();
+	foreach (var address in vars.collectibleAddresses) {
+		settings.Add(address.Value+"All", false, address.Value+" (All Done)", "Collectibles");
+		settings.Add(address.Value+"Each", false, address.Value+" (Each)", "Collectibles");
+		vars.collectList.Add(address.Value);
+	}
+	
 	// Setting for final split of Any%.
 	settings.Add("btgFinalSplit", false, "Any% Final Split");
 	settings.SetToolTip("btgFinalSplit", "Splits once you lose control on \"The Exchange\".");
@@ -133,6 +150,10 @@ init
 	// Adds mission memory addresses (with the correct offset) to the watcher list.
 	vars.memoryWatchers = new MemoryWatcherList();
 	foreach (var address in vars.missionAddresses)
+		vars.memoryWatchers.Add(new MemoryWatcher<int>(new DeepPointer(address.Key+vars.offset)) { Name = address.Value });
+	
+	// Adds collectible memory addresses (with the correct offset) to the watcher list.
+	foreach (var address in vars.collectibleAddresses)
 		vars.memoryWatchers.Add(new MemoryWatcher<int>(new DeepPointer(address.Key+vars.offset)) { Name = address.Value });
 	
 	// Add memory address for the "game state" to the watcher list.
@@ -174,9 +195,44 @@ split
 		}
 	}
 	
+	// Goes through all collectibles in the list, attempts to not split twice for the same collectible.
+	foreach (var collectible in vars.collectList) {
+		var cvalue = vars.memoryWatchers[collectible];
+		if(cvalue.Current > cvalue.Old) {
+			if (settings[collectible+"All"])
+			{
+				int max = 20;
+				if (collectible == "Hidden Packages")
+				{
+					max = 100;
+				}
+				if(cvalue.Current == max && cvalue.Old == max-1)
+				{
+					var splitName = collectible+" "+cvalue.Current;
+					if(!vars.split.Contains(splitName))
+					{
+						vars.split.Add(splitName);
+						return true;
+					}
+				}
+			}
+			if (settings[collectible+"Each"])
+			{
+				var splitName = collectible+" "+cvalue.Current;
+				if(!vars.split.Contains(splitName))
+				{
+					vars.split.Add(splitName);
+					return true;
+				}
+			}
+		}
+	}
+	
 	// Splits for the final split of Any%.
 	if (settings["btgFinalSplit"] && vars.memoryWatchers["teHelipad"].Current == 1 && vars.memoryWatchers["teTimer"].Current != vars.memoryWatchers["teTimer"].Old)
 		return true;
+		
+	// Splits on 100% game completion.
 	if (settings["hundoFinalSplit"] && vars.memoryWatchers["progressMade"].Current == 154 && vars.memoryWatchers["progressMade"].Old != vars.memoryWatchers["progressMade"].Current)
 		return true;
 }

--- a/Release/LiveSplit.GTA3.asl
+++ b/Release/LiveSplit.GTA3.asl
@@ -97,6 +97,23 @@ startup
 		vars.missionList.Add(address.Value);
 	}
 	
+	
+	// Collectibles
+	vars.collectibleAddresses = new Dictionary<int, string> {
+		{0x35C3D4,"Hidden Packages"},
+		{0x35C0AC,"Rampages"},
+		{0x35BFB0,"Unique Stunt Jumps"}
+	};
+	
+	settings.Add("Collectibles", false, "Collectibles");
+	
+	vars.collectList = new List<string>();
+	foreach (var address in vars.collectibleAddresses) {
+		settings.Add(address.Value+"All", false, address.Value+" (All Done)", "Collectibles");
+		settings.Add(address.Value+"Each", false, address.Value+" (Each)", "Collectibles");
+		vars.collectList.Add(address.Value);
+	}
+	
 	// Setting for final split of Any%.
 	settings.Add("btgFinalSplit", false, "Any% Final Split");
 	settings.SetToolTip("btgFinalSplit", "Splits once you lose control on \"The Exchange\".");
@@ -133,6 +150,10 @@ init
 	// Adds mission memory addresses (with the correct offset) to the watcher list.
 	vars.memoryWatchers = new MemoryWatcherList();
 	foreach (var address in vars.missionAddresses)
+		vars.memoryWatchers.Add(new MemoryWatcher<int>(new DeepPointer(address.Key+vars.offset)) { Name = address.Value });
+	
+	// Adds collectible memory addresses (with the correct offset) to the watcher list.
+	foreach (var address in vars.collectibleAddresses)
 		vars.memoryWatchers.Add(new MemoryWatcher<int>(new DeepPointer(address.Key+vars.offset)) { Name = address.Value });
 	
 	// Add memory address for the "game state" to the watcher list.
@@ -174,9 +195,44 @@ split
 		}
 	}
 	
+	// Goes through all collectibles in the list, attempts to not split twice for the same collectible.
+	foreach (var collectible in vars.collectList) {
+		var cvalue = vars.memoryWatchers[collectible];
+		if(cvalue.Current > cvalue.Old) {
+			if (settings[collectible+"All"])
+			{
+				int max = 20;
+				if (collectible == "Hidden Packages")
+				{
+					max = 100;
+				}
+				if(cvalue.Current == max && cvalue.Old == max-1)
+				{
+					var splitName = collectible+" "+cvalue.Current;
+					if(!vars.split.Contains(splitName))
+					{
+						vars.split.Add(splitName);
+						return true;
+					}
+				}
+			}
+			if (settings[collectible+"Each"])
+			{
+				var splitName = collectible+" "+cvalue.Current;
+				if(!vars.split.Contains(splitName))
+				{
+					vars.split.Add(splitName);
+					return true;
+				}
+			}
+		}
+	}
+	
 	// Splits for the final split of Any%.
 	if (settings["btgFinalSplit"] && vars.memoryWatchers["teHelipad"].Current == 1 && vars.memoryWatchers["teTimer"].Current != vars.memoryWatchers["teTimer"].Old)
 		return true;
+		
+	// Splits on 100% game completion.
 	if (settings["hundoFinalSplit"] && vars.memoryWatchers["progressMade"].Current == 154 && vars.memoryWatchers["progressMade"].Old != vars.memoryWatchers["progressMade"].Current)
 		return true;
 }


### PR DESCRIPTION
adds splitters for:
* Unique Stunt Jumps
* Rampages
* Hidden Packages

it follows the same theme as SA/VC autosplitters, having options for (Each) and (All Done)
didn't have time to test out All Done, Each is tested and working.

+ added a missing comment about 100% final split.