### PR TITLE
gta3: set asl refreshRate to 30

### DIFF
--- a/LiveSplit.GTA3-NEW.asl
+++ b/LiveSplit.GTA3-NEW.asl
@@ -11,6 +11,9 @@ state("gta3", "Steam") {}
 
 startup
 {
+	// Set the autosplitter refresh rate (lower = less CPU and less accurate, higher = more CPU usage and more accurate) default: 60
+	refreshRate = 30;
+	
 	// List of mission memory addresses (for Steam, see below for where offsets get added).
 	vars.missionAddresses = new Dictionary<int, string> {
 		{0x35B75C, "Give Me Liberty and Luigi's Girls"},

--- a/Release/LiveSplit.GTA3.asl
+++ b/Release/LiveSplit.GTA3.asl
@@ -11,6 +11,9 @@ state("gta3", "Steam") {}
 
 startup
 {
+	// Set the autosplitter refresh rate (lower = less CPU and less accurate, higher = more CPU usage and more accurate) default: 60
+	refreshRate = 30;
+	
 	// List of mission memory addresses (for Steam, see below for where offsets get added).
 	vars.missionAddresses = new Dictionary<int, string> {
 		{0x35B75C, "Give Me Liberty and Luigi's Girls"},


### PR DESCRIPTION
use the built-in refreshRate variable to reduce CPU usage, from default of 60 to 30.