### PR TITLE
gta3: add support for JP ver, add splitter for mission starts

### DIFF
--- a/LiveSplit.GTA3-NEW.asl
+++ b/LiveSplit.GTA3-NEW.asl
@@ -2,12 +2,14 @@ state("gta3")
 {
 	int versionCheck10 : 0x1C1E70; // 1407551829 if we're on version 1.0.
 	int versionCheck11 : 0x1C2130; // 1407551829 if we're on version 1.1.
+	int versionCheckJP : 0x1B52D0; // 1407551829 if we're on japanese version.
 }
 
 // These need to exist so they are actually found as versions by the code below.
 state("gta3", "1.0") {}
 state("gta3", "1.1") {}
 state("gta3", "Steam") {}
+state("gta3", "Japanese") {}
 
 startup
 {
@@ -16,7 +18,7 @@ startup
 	
 	// List of mission memory addresses (for Steam, see below for where offsets get added).
 	vars.missionAddresses = new Dictionary<int, string> {
-		{0x35B75C, "Give Me Liberty and Luigi's Girls"},
+		{0x35B75C, "Luigi's Girls"},
 		{0x35B76C, "Don't Spank Ma Bitch Up"},
 		{0x35B770, "Drive Misty For Me"},
 		{0x35B80C, "The Crook"},
@@ -38,12 +40,12 @@ startup
 		{0x35B7B8, "Cutting the Grass"},
 		{0x35B7A8, "Triads and Tribulations"},
 		{0x35B774, "Pump-Action Pimp"},
-		{0x35B9EC, "RC Diablo Destruction"},
+		{0x35B9EC, "Diablo Destruction"},
 		{0x35B778, "The Fuzz Ball"},
 		{0x35B7E4, "I Scream, You Scream"},
 		{0x35B7E8, "Trial By Fire"},
-		{0x35B7EC, "Big 'N' Veiny"},
-		{0x35B9F0, "RC Mafia Massacre"},
+		{0x35B7EC, "Big'N'Veiny"},
+		{0x35B9F0, "Mafia Massacre"},
 		{0x35B7AC, "Blow Fish"},
 		{0x35B7BC, "Bomb Da Base: Act I"},
 		{0x35B7C0, "Bomb Da Base: Act II"},
@@ -51,8 +53,8 @@ startup
 		{0x35B878, "Sayonara Salvatore"},
 		{0x35B8D4, "Bling-Bling Scramble"},
 		{0x35B87C, "Under Surveillance"},
-		{0x35B8AC, "Kanbu Bust Out"},
-		{0x35B9F8, "RC Casino Calamity"},
+		{0x35B8AC, "Kanbu Bust-Out"},
+		{0x35B9F8, "Casino Calamity"},
 		{0x35B8B0, "Grand Theft Auto"},
 		{0x35B8D8, "Uzi Rider"},
 		{0x35B97C, "Multistorey Mayhem"},
@@ -71,12 +73,12 @@ startup
 		{0x35B8A0, "Plaster Blaster"},
 		{0x35B8E0, "Kingdom Come"},
 		{0x35B8C4, "Liberator"},
-		{0x35B8C8, "Waka-Gashira Wipeout"},
+		{0x35B8C8, "Waka-Gashira Wipeout!"},
 		{0x35B8CC, "A Drop In The Ocean"},
 		{0x35B8FC, "Grand Theft Aero"},
 		{0x35B8A4, "Marked Man"},
 		{0x35B900, "Escort Service"},
-		{0x35B9F4, "RC Rumpo Rampage"},
+		{0x35B9F4, "Rumpo Rampage"},
 		{0x35B924, "Uzi Money"},
 		{0x35B928, "Toyminator"},
 		{0x35B92C, "Rigged to Blow"},
@@ -85,21 +87,24 @@ startup
 		{0x35B904, "Decoy"},
 		{0x35B908, "Love's Disappearance"},
 		{0x35B914, "Espresso-2-Go!"},
-		{0x35B918, "S.A.M. + Ransom"},
+		{0x35B918, "S.A.M."},
 		{0x35B948, "The Exchange"},
 		{0x35B934, "Rumble"},
 		{0x35B978, "Gripped!"}
 	};
 	
-	settings.Add("Missions", false, "Missions");
+	settings.Add("Missions (start)", false, "Missions (start)");
+	settings.Add("Missions (complete)", false, "Missions (complete)");
 	
 	// Adds missions to the settings and also to a separate list for easier checking later.
 	vars.missionList = new List<string>();
+	vars.missionStartList = new List<string>();
 	foreach (var address in vars.missionAddresses) {
-		settings.Add(address.Value, false, address.Value, "Missions");
+		settings.Add(address.Value + " (start)", false, address.Value, "Missions (start)");
+		settings.Add(address.Value, false, address.Value, "Missions (complete)");
+		vars.missionStartList.Add(address.Value + " (start)");
 		vars.missionList.Add(address.Value);
 	}
-	
 	
 	// Collectibles
 	vars.collectibleAddresses = new Dictionary<int, string> {
@@ -150,6 +155,12 @@ init
 		vars.offset = -0x10140;
 	}
 	
+	// JP version check.
+	else if (current.versionCheckJP == 1407551829) {
+		version = "Japanese";
+		vars.offset = -0x21E0;
+	}
+	
 	// Adds mission memory addresses (with the correct offset) to the watcher list.
 	vars.memoryWatchers = new MemoryWatcherList();
 	foreach (var address in vars.missionAddresses)
@@ -160,14 +171,24 @@ init
 		vars.memoryWatchers.Add(new MemoryWatcher<int>(new DeepPointer(address.Key+vars.offset)) { Name = address.Value });
 	
 	// Add memory address for the "game state" to the watcher list.
-	vars.memoryWatchers.Add(new MemoryWatcher<int>(new DeepPointer(0x505A2C+vars.offset)) { Name = "gameState" });
+	var gameStateAddress = (version == "Japanese") ? 0x50387C : 0x505A2C+vars.offset;
+	vars.memoryWatchers.Add(new MemoryWatcher<int>(new DeepPointer(gameStateAddress)) { Name = "gameState" });
+	
+	// JP version game state is shifted by 4.
+	vars.gameStateShift = (version == "Japanese") ? 4 : 0;
 	
 	// Memory addresses used for the final split of Any% (see below).
 	vars.memoryWatchers.Add(new MemoryWatcher<byte>(new DeepPointer(0x35F6B8+vars.offset)) { Name = "teHelipad" });
 	vars.memoryWatchers.Add(new MemoryWatcher<int>(new DeepPointer(0x35BA2C+vars.offset)) { Name = "teTimer" });
 	
 	// Memory address used for percentage checking 
-	vars.memoryWatchers.Add(new MemoryWatcher<int>(new DeepPointer(0x50651C+vars.offset)) { Name = "progressMade" });
+	var progressMadeAddress = (version == "Japanese") ? 0x50436C : 0x50651C+vars.offset;
+	vars.memoryWatchers.Add(new MemoryWatcher<int>(new DeepPointer(progressMadeAddress)) { Name = "progressMade" });
+	
+	// Memory address used to read mission titles.
+	var missionTextAddress = (version == "Japanese") ? 0x272AE8 : 0x274F20 + vars.offset;
+	vars.memoryWatchers.Add(new StringWatcher(new DeepPointer(missionTextAddress), 64) { Name = "missionText" });
+	
 }
 
 update
@@ -195,6 +216,36 @@ split
 		if (settings[mission] && vars.memoryWatchers[mission].Current > vars.memoryWatchers[mission].Old && !vars.split.Contains(mission)) {
 			vars.split.Add(mission);
 			return true;
+		}
+	}
+	
+	// Same as above but for mission starts.
+	foreach (var mission in vars.missionStartList) {
+		var missionText = vars.memoryWatchers["missionText"].Current;
+		var upperMission = mission.ToUpper();
+		upperMission = upperMission.Replace(" (START)", string.Empty);
+		
+		if (version == "Japanese")
+		{
+			if (upperMission.Equals("TURISMO"))
+			{
+				upperMission = "ROAD RACING";
+			}
+			if (upperMission.Equals("BOMB DA BASE: ACT I"))
+			{
+				upperMission = "BOMB DA BASE -ACT 1-";
+			}
+			if (upperMission.Equals("BOMB DA BASE: ACT II"))
+			{	
+				upperMission = "BOMB DA BASE -ACT 2-";
+			}
+		}
+		
+		if (settings[mission] && !missionText.Equals(vars.memoryWatchers["missionText"].Old) && !vars.split.Contains("s" + upperMission)) {
+			if (version == "Japanese" ? missionText.Equals(upperMission) : missionText.Equals("'" + upperMission + "'")) {
+				vars.split.Add("s" + upperMission);
+				return true;
+			}
 		}
 	}
 	
@@ -243,13 +294,13 @@ split
 start
 {
 	// Starts the splits after the loading bar disappears.
-	return vars.memoryWatchers["gameState"].Old == 8
-	&& vars.memoryWatchers["gameState"].Current == 9;
+	return vars.memoryWatchers["gameState"].Old == 8+vars.gameStateShift
+	&& vars.memoryWatchers["gameState"].Current == 9+vars.gameStateShift;
 }
 
 reset
 {
 	// Resets the timer when the new game load starts.
-	return vars.memoryWatchers["gameState"].Old == 9
-	&& vars.memoryWatchers["gameState"].Current == 8;
+	return vars.memoryWatchers["gameState"].Old == 9+vars.gameStateShift
+	&& vars.memoryWatchers["gameState"].Current == 8+vars.gameStateShift;
 }

--- a/Release/LiveSplit.GTA3.asl
+++ b/Release/LiveSplit.GTA3.asl
@@ -2,12 +2,14 @@ state("gta3")
 {
 	int versionCheck10 : 0x1C1E70; // 1407551829 if we're on version 1.0.
 	int versionCheck11 : 0x1C2130; // 1407551829 if we're on version 1.1.
+	int versionCheckJP : 0x1B52D0; // 1407551829 if we're on japanese version.
 }
 
 // These need to exist so they are actually found as versions by the code below.
 state("gta3", "1.0") {}
 state("gta3", "1.1") {}
 state("gta3", "Steam") {}
+state("gta3", "Japanese") {}
 
 startup
 {
@@ -16,7 +18,7 @@ startup
 	
 	// List of mission memory addresses (for Steam, see below for where offsets get added).
 	vars.missionAddresses = new Dictionary<int, string> {
-		{0x35B75C, "Give Me Liberty and Luigi's Girls"},
+		{0x35B75C, "Luigi's Girls"},
 		{0x35B76C, "Don't Spank Ma Bitch Up"},
 		{0x35B770, "Drive Misty For Me"},
 		{0x35B80C, "The Crook"},
@@ -38,12 +40,12 @@ startup
 		{0x35B7B8, "Cutting the Grass"},
 		{0x35B7A8, "Triads and Tribulations"},
 		{0x35B774, "Pump-Action Pimp"},
-		{0x35B9EC, "RC Diablo Destruction"},
+		{0x35B9EC, "Diablo Destruction"},
 		{0x35B778, "The Fuzz Ball"},
 		{0x35B7E4, "I Scream, You Scream"},
 		{0x35B7E8, "Trial By Fire"},
-		{0x35B7EC, "Big 'N' Veiny"},
-		{0x35B9F0, "RC Mafia Massacre"},
+		{0x35B7EC, "Big'N'Veiny"},
+		{0x35B9F0, "Mafia Massacre"},
 		{0x35B7AC, "Blow Fish"},
 		{0x35B7BC, "Bomb Da Base: Act I"},
 		{0x35B7C0, "Bomb Da Base: Act II"},
@@ -51,8 +53,8 @@ startup
 		{0x35B878, "Sayonara Salvatore"},
 		{0x35B8D4, "Bling-Bling Scramble"},
 		{0x35B87C, "Under Surveillance"},
-		{0x35B8AC, "Kanbu Bust Out"},
-		{0x35B9F8, "RC Casino Calamity"},
+		{0x35B8AC, "Kanbu Bust-Out"},
+		{0x35B9F8, "Casino Calamity"},
 		{0x35B8B0, "Grand Theft Auto"},
 		{0x35B8D8, "Uzi Rider"},
 		{0x35B97C, "Multistorey Mayhem"},
@@ -71,12 +73,12 @@ startup
 		{0x35B8A0, "Plaster Blaster"},
 		{0x35B8E0, "Kingdom Come"},
 		{0x35B8C4, "Liberator"},
-		{0x35B8C8, "Waka-Gashira Wipeout"},
+		{0x35B8C8, "Waka-Gashira Wipeout!"},
 		{0x35B8CC, "A Drop In The Ocean"},
 		{0x35B8FC, "Grand Theft Aero"},
 		{0x35B8A4, "Marked Man"},
 		{0x35B900, "Escort Service"},
-		{0x35B9F4, "RC Rumpo Rampage"},
+		{0x35B9F4, "Rumpo Rampage"},
 		{0x35B924, "Uzi Money"},
 		{0x35B928, "Toyminator"},
 		{0x35B92C, "Rigged to Blow"},
@@ -85,21 +87,24 @@ startup
 		{0x35B904, "Decoy"},
 		{0x35B908, "Love's Disappearance"},
 		{0x35B914, "Espresso-2-Go!"},
-		{0x35B918, "S.A.M. + Ransom"},
+		{0x35B918, "S.A.M."},
 		{0x35B948, "The Exchange"},
 		{0x35B934, "Rumble"},
 		{0x35B978, "Gripped!"}
 	};
 	
-	settings.Add("Missions", false, "Missions");
+	settings.Add("Missions (start)", false, "Missions (start)");
+	settings.Add("Missions (complete)", false, "Missions (complete)");
 	
 	// Adds missions to the settings and also to a separate list for easier checking later.
 	vars.missionList = new List<string>();
+	vars.missionStartList = new List<string>();
 	foreach (var address in vars.missionAddresses) {
-		settings.Add(address.Value, false, address.Value, "Missions");
+		settings.Add(address.Value + " (start)", false, address.Value, "Missions (start)");
+		settings.Add(address.Value, false, address.Value, "Missions (complete)");
+		vars.missionStartList.Add(address.Value + " (start)");
 		vars.missionList.Add(address.Value);
 	}
-	
 	
 	// Collectibles
 	vars.collectibleAddresses = new Dictionary<int, string> {
@@ -150,6 +155,12 @@ init
 		vars.offset = -0x10140;
 	}
 	
+	// JP version check.
+	else if (current.versionCheckJP == 1407551829) {
+		version = "Japanese";
+		vars.offset = -0x21E0;
+	}
+	
 	// Adds mission memory addresses (with the correct offset) to the watcher list.
 	vars.memoryWatchers = new MemoryWatcherList();
 	foreach (var address in vars.missionAddresses)
@@ -160,14 +171,24 @@ init
 		vars.memoryWatchers.Add(new MemoryWatcher<int>(new DeepPointer(address.Key+vars.offset)) { Name = address.Value });
 	
 	// Add memory address for the "game state" to the watcher list.
-	vars.memoryWatchers.Add(new MemoryWatcher<int>(new DeepPointer(0x505A2C+vars.offset)) { Name = "gameState" });
+	var gameStateAddress = (version == "Japanese") ? 0x50387C : 0x505A2C+vars.offset;
+	vars.memoryWatchers.Add(new MemoryWatcher<int>(new DeepPointer(gameStateAddress)) { Name = "gameState" });
+	
+	// JP version game state is shifted by 4.
+	vars.gameStateShift = (version == "Japanese") ? 4 : 0;
 	
 	// Memory addresses used for the final split of Any% (see below).
 	vars.memoryWatchers.Add(new MemoryWatcher<byte>(new DeepPointer(0x35F6B8+vars.offset)) { Name = "teHelipad" });
 	vars.memoryWatchers.Add(new MemoryWatcher<int>(new DeepPointer(0x35BA2C+vars.offset)) { Name = "teTimer" });
 	
 	// Memory address used for percentage checking 
-	vars.memoryWatchers.Add(new MemoryWatcher<int>(new DeepPointer(0x50651C+vars.offset)) { Name = "progressMade" });
+	var progressMadeAddress = (version == "Japanese") ? 0x50436C : 0x50651C+vars.offset;
+	vars.memoryWatchers.Add(new MemoryWatcher<int>(new DeepPointer(progressMadeAddress)) { Name = "progressMade" });
+	
+	// Memory address used to read mission titles.
+	var missionTextAddress = (version == "Japanese") ? 0x272AE8 : 0x274F20 + vars.offset;
+	vars.memoryWatchers.Add(new StringWatcher(new DeepPointer(missionTextAddress), 64) { Name = "missionText" });
+	
 }
 
 update
@@ -195,6 +216,36 @@ split
 		if (settings[mission] && vars.memoryWatchers[mission].Current > vars.memoryWatchers[mission].Old && !vars.split.Contains(mission)) {
 			vars.split.Add(mission);
 			return true;
+		}
+	}
+	
+	// Same as above but for mission starts.
+	foreach (var mission in vars.missionStartList) {
+		var missionText = vars.memoryWatchers["missionText"].Current;
+		var upperMission = mission.ToUpper();
+		upperMission = upperMission.Replace(" (START)", string.Empty);
+		
+		if (version == "Japanese")
+		{
+			if (upperMission.Equals("TURISMO"))
+			{
+				upperMission = "ROAD RACING";
+			}
+			if (upperMission.Equals("BOMB DA BASE: ACT I"))
+			{
+				upperMission = "BOMB DA BASE -ACT 1-";
+			}
+			if (upperMission.Equals("BOMB DA BASE: ACT II"))
+			{	
+				upperMission = "BOMB DA BASE -ACT 2-";
+			}
+		}
+		
+		if (settings[mission] && !missionText.Equals(vars.memoryWatchers["missionText"].Old) && !vars.split.Contains("s" + upperMission)) {
+			if (version == "Japanese" ? missionText.Equals(upperMission) : missionText.Equals("'" + upperMission + "'")) {
+				vars.split.Add("s" + upperMission);
+				return true;
+			}
 		}
 	}
 	
@@ -243,13 +294,13 @@ split
 start
 {
 	// Starts the splits after the loading bar disappears.
-	return vars.memoryWatchers["gameState"].Old == 8
-	&& vars.memoryWatchers["gameState"].Current == 9;
+	return vars.memoryWatchers["gameState"].Old == 8+vars.gameStateShift
+	&& vars.memoryWatchers["gameState"].Current == 9+vars.gameStateShift;
 }
 
 reset
 {
 	// Resets the timer when the new game load starts.
-	return vars.memoryWatchers["gameState"].Old == 9
-	&& vars.memoryWatchers["gameState"].Current == 8;
+	return vars.memoryWatchers["gameState"].Old == 9+vars.gameStateShift
+	&& vars.memoryWatchers["gameState"].Current == 8+vars.gameStateShift;
 }


### PR DESCRIPTION
adds support for mission start splits (as well as keeping mission complete splits), per split basis
adds support for JP version
fixes some incorrect mission names
