### PR TITLE
Update LiveSplit.WatchDogs2.asl

### DIFF
--- a/LiveSplit.WatchDogs2-README.md
+++ b/LiveSplit.WatchDogs2-README.md
@@ -1,15 +1,21 @@
-# "Watch_Dogs 2" Load Remover
+# "Watch_Dogs 2" Autosplitter and Load Remover
 
-**How to install:**
+## How to install
 
 1. In the LiveSplit splits editor, make sure your game is set to "Watch_Dogs 2" (without quotes) and then click the "Activate" button.
 2. Disable **EasyAntiCheat** for the game; this can be done by adding the `-eac_launcher` command line option. This is needed because it blocks the game's memory from being read. The game should alert you that this has worked on start up; if it doesn't, try restarting your computer and then launching the game again.
     - See [this PCGamingWiki article](http://pcgamingwiki.com/wiki/Glossary:Command_line_arguments) for how to go about doing this.
 3. In LiveSplit, set "Game Time" as your main timing method; right-click the main window > Compare Against > Game Time. (Both real time and time without loads are stored in your splits regardless.)
 
-**Versions supported:**
+## What is autosplit?
 
-This load remover *should* work for copies bought from any storefront. Your current version is visible in the main menu and the pause menu. I advise you disable automatic updating of your game if possible, because new versions will not be supported straight away.
+*(All autospliting is based on follower counts.)*
+- Splits for all main missions.
+- Split for buying pants at the start of the game, if enabled in settings.
+
+## Versions supported
+
+This load remover *should* work for copies bought from any storefront. Your current version is visible in the main menu and the pause menu. I advise you disable automatic updating of your game if possible, because new versions will not be supported straight away. **Autosplitting is not supported on all versions! (see notes below)**
 - v1.05.134.981608
 - v1.06.135.3.982778
 - v1.06.135.7.982778
@@ -17,5 +23,9 @@ This load remover *should* work for copies bought from any storefront. Your curr
 - v1.09.152.2.996015
 - v1.09.154.1001103
 - v1.011.174.3.1009368
-- v1.011.174.6.1009368
-- v1.017.189.2.1088394 ([final patch?](https://www.reddit.com/r/watch_dogs/comments/6r7vbr/title_update_117_bug_fix_patch_notes/))
+- v1.011.174.6.1009368 (**supports autosplitting**)
+- v1.017.189.2.1088394 (**supports autosplitting**, [final patch?](https://www.reddit.com/r/watch_dogs/comments/6r7vbr/title_update_117_bug_fix_patch_notes/))
+
+## Contributors
+
+- Random_Machine *(autosplitting)*

--- a/LiveSplit.WatchDogs2.asl
+++ b/LiveSplit.WatchDogs2.asl
@@ -56,24 +56,21 @@ state("WatchDogs2", "v1.011.174.6.1009368")
 {
 	int loading1 : "Disrupt_64.dll", 0x3E69E1C;
 	int loading2 : "Disrupt_64.dll", 0x3E13B34;
-	
-	int followers: "Disrupt_64.dll", 0x3E157F0, 0xD0, 0x40, 0xD0, 0x80, 0x38, 0x30, 0xC0;
+	int followers : "Disrupt_64.dll", 0x3E157F0, 0xD0, 0x40, 0xD0, 0x80, 0x38, 0x30, 0xC0;
 }
 
 state("WatchDogs2", "v1.017.189.2.1088394")
 {
 	int loading1 : "Disrupt_64.dll", 0x401E824;
 	int loading2 : "Disrupt_64.dll", 0x3FC34B4;
-	
-	int followers: "Disrupt_64.dll", 0x401AC10, 0xC8, 0x8, 0x168, 0xE0, 0xC0;
+	int followers : "Disrupt_64.dll", 0x401AC10, 0xC8, 0x8, 0x168, 0xE0, 0xC0;
 }
 
-startup {
-	
-	settings.Add("Buy Pants", true, "Splits after buying pants at beginning of game");
-	
+startup
+{
+	settings.Add("BuyPants", true, "Split for buying pants");
+	settings.SetToolTip("BuyPants", "Splits after buying pants at the beginning of the game.");
 }
-
 
 init
 {
@@ -113,46 +110,33 @@ init
 isLoading
 {
 	if (version != "")
-		return current.loading1 > 0 || current.loading2 > 0;		
+		return current.loading1 > 0 || current.loading2 > 0;
 }
 
-
-split{  
-
-	if(settings["Buy Pants"] && current.followers==old.followers+2200) //Buying Pants Finished
+split
+{
+	if (settings["Buy Pants"] && current.followers == old.followers + 2200) // Buying Pants Finished
 		return true;
-
-	if(current.followers==old.followers+46000) //Cyberdriver Finished
+	if (current.followers == old.followers + 46000) // Cyberdriver Finished
 		return true;
-
-	if(current.followers==old.followers+96000) //False Profits Finished
+	if (current.followers == old.followers + 96000) // False Profits Finished
 		return true;
-
-	if(current.followers==old.followers+87000) //Haum Sweet Haum Finished
+	if (current.followers == old.followers + 87000) // Haum Sweet Haum Finished
 		return true;
-	
-	if(current.followers==old.followers+200000) //Looking Glass or Limp Nudle Finished
+	if (current.followers == old.followers + 200000) // Looking Glass or Limp Nudle Finished
 		return true;
-
-	if(current.followers==old.followers+233000) //Hacker War Finished
+	if (current.followers == old.followers + 233000) // Hacker War Finished
 		return true;
-	
-	if(current.followers==old.followers+242000) //W4tched Finished
+	if (current.followers == old.followers + 242000) // W4tched Finished
 		return true;
-	
-	if(current.followers==old.followers+234900) //Eye for an Eye Finished
+	if (current.followers == old.followers + 234900) // Eye for an Eye Finished
 		return true;
-
-	if(current.followers==old.followers+364000) //Hack teh World Finished
+	if (current.followers == old.followers + 364000) // Hack teh World Finished
 		return true;
-
-	if(current.followers==old.followers+542400) //Shanghaied Finished
+	if (current.followers == old.followers + 542400) // Shanghaied Finished
 		return true;
-
-	if(current.followers==old.followers+402800) //Power to the Sheeple Finished
+	if (current.followers == old.followers + 402800) // Power to the Sheeple Finished
 		return true;
-
-	if(current.followers==old.followers+464000) //Robot Wars Finished
+	if (current.followers == old.followers + 464000) // Robot Wars Finished
 		return true;
-	
 }

--- a/LiveSplit.WatchDogs2.asl
+++ b/LiveSplit.WatchDogs2.asl
@@ -56,13 +56,24 @@ state("WatchDogs2", "v1.011.174.6.1009368")
 {
 	int loading1 : "Disrupt_64.dll", 0x3E69E1C;
 	int loading2 : "Disrupt_64.dll", 0x3E13B34;
+	
+	int followers: "Disrupt_64.dll", 0x3E157F0, 0xD0, 0x40, 0xD0, 0x80, 0x38, 0x30, 0xC0;
 }
 
 state("WatchDogs2", "v1.017.189.2.1088394")
 {
 	int loading1 : "Disrupt_64.dll", 0x401E824;
 	int loading2 : "Disrupt_64.dll", 0x3FC34B4;
+	
+	int followers: "Disrupt_64.dll", 0x401AC10, 0xC8, 0x8, 0x168, 0xE0, 0xC0;
 }
+
+startup {
+	
+	settings.Add("Buy Pants", true, "Splits after buying pants at beginning of game");
+	
+}
+
 
 init
 {
@@ -102,5 +113,46 @@ init
 isLoading
 {
 	if (version != "")
-		return current.loading1 > 0 || current.loading2 > 0;
+		return current.loading1 > 0 || current.loading2 > 0;		
+}
+
+
+split{  
+
+	if(settings["Buy Pants"] && current.followers==old.followers+2200) //Buying Pants Finished
+		return true;
+
+	if(current.followers==old.followers+46000) //Cyberdriver Finished
+		return true;
+
+	if(current.followers==old.followers+96000) //False Profits Finished
+		return true;
+
+	if(current.followers==old.followers+87000) //Haum Sweet Haum Finished
+		return true;
+	
+	if(current.followers==old.followers+200000) //Looking Glass or Limp Nudle Finished
+		return true;
+
+	if(current.followers==old.followers+233000) //Hacker War Finished
+		return true;
+	
+	if(current.followers==old.followers+242000) //W4tched Finished
+		return true;
+	
+	if(current.followers==old.followers+234900) //Eye for an Eye Finished
+		return true;
+
+	if(current.followers==old.followers+364000) //Hack teh World Finished
+		return true;
+
+	if(current.followers==old.followers+542400) //Shanghaied Finished
+		return true;
+
+	if(current.followers==old.followers+402800) //Power to the Sheeple Finished
+		return true;
+
+	if(current.followers==old.followers+464000) //Robot Wars Finished
+		return true;
+	
 }

--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ If you're watching his video for *The Simpsons: Hit & Run* and have been sent he
 - For information about the "Grand Theft Auto V" load remover, please [go here](http://www.speedrun.com/gtav/guide/fhod2).
 - For information about the "Grand Theft Auto: Vice City" autosplitter, please [go here](https://github.com/zoton2/LiveSplit.Scripts/blob/master/LiveSplit.GTAVC-README.md).
 - For information about the "Grand Theft Auto 3/III" autosplitter, please [go here](https://github.com/zoton2/LiveSplit.Scripts/blob/master/LiveSplit.GTA3-README.md).
-- For information about the "Watch_Dogs 2" load remover, please [go here](https://github.com/zoton2/LiveSplit.Scripts/blob/master/LiveSplit.WatchDogs2-README.md).
+- For information about the "Watch_Dogs 2" autosplitter/load remover, please [go here](https://github.com/zoton2/LiveSplit.Scripts/blob/master/LiveSplit.WatchDogs2-README.md).
 
 Anything stored within the `Release` directory can be used within LiveSplit without any extra downloading, by going to the splits editor, setting the game name correctly and clicking on the "Activate" button.


### PR DESCRIPTION
Adds autosplitting for main missions in v1.011.174.3.1009368 and v1.017.189.2.1088394 via follower count. There is also an added option to enable/disable splitting for buying pants at the beginning of the game. 