### PR TITLE
Update LiveSplit.WatchDogs2.asl

### DIFF
--- a/LiveSplit.WatchDogs2.asl
+++ b/LiveSplit.WatchDogs2.asl
@@ -57,6 +57,7 @@ state("WatchDogs2", "v1.011.174.6.1009368")
 	int loading1 : "Disrupt_64.dll", 0x3E69E1C;
 	int loading2 : "Disrupt_64.dll", 0x3E13B34;
 	int followers : "Disrupt_64.dll", 0x3E157F0, 0xD0, 0x40, 0xD0, 0x80, 0x38, 0x30, 0xC0;
+	int LineId: "Disrupt_64.dll", 0x3C82108, 0x288, 0x90, 0x190, 0xB8, 0x9E8;
 }
 
 state("WatchDogs2", "v1.017.189.2.1088394")
@@ -64,12 +65,33 @@ state("WatchDogs2", "v1.017.189.2.1088394")
 	int loading1 : "Disrupt_64.dll", 0x401E824;
 	int loading2 : "Disrupt_64.dll", 0x3FC34B4;
 	int followers : "Disrupt_64.dll", 0x401AC10, 0xC8, 0x8, 0x168, 0xE0, 0xC0;
+	int LineId: "Disrupt_64.dll", 0x400FA90, 0x28;
 }
 
 startup
 {
-	settings.Add("BuyPants", true, "Split for buying pants");
+	settings.Add("BuyPants", false, "Split for buying pants");
 	settings.SetToolTip("BuyPants", "Splits after buying pants at the beginning of the game.");
+	
+	Action<string> logDebug = (text) => {
+        	print("[Watch_Dogs 2 Autosplitter | DEBUG] "+ text);
+    		};
+   		vars.logDebug = logDebug;
+	vars.lastSplitTime = null;
+	Func<bool> isNotDoubleSplit = () => {
+		bool isDoubleSplit = false;
+		if (vars.lastSplitTime != null) {
+			System.TimeSpan ts = System.DateTime.Now - vars.lastSplitTime;
+			if (ts.TotalSeconds < 15) {
+				isDoubleSplit = true;
+				vars.logDebug("Double split detected!");
+			}
+		}
+		vars.lastSplitTime = System.DateTime.Now;
+		return !isDoubleSplit;
+	};
+	vars.isNotDoubleSplit = isNotDoubleSplit;
+	
 }
 
 init
@@ -113,10 +135,22 @@ isLoading
 		return current.loading1 > 0 || current.loading2 > 0;
 }
 
+start{
+
+	if (vars.stopwatch.ElapsedMilliseconds > 6000)
+		vars.stopwatch.Reset();
+	if (current.LineId == 693964)
+		vars.stopwatch.Start();
+	if (current.LineId == 693964 && vars.stopwatch.ElapsedMilliseconds > 5066.67)
+		return true;	
+}
+
 split
 {
 	if (settings["Buy Pants"] && current.followers == old.followers + 2200) // Buying Pants Finished
 		return true;
+	if(old.LineId == 658785 && current.LineId > 100000) //Walk in the Park Finished  
+		return vars.isNotDoubleSplit();
 	if (current.followers == old.followers + 46000) // Cyberdriver Finished
 		return true;
 	if (current.followers == old.followers + 96000) // False Profits Finished

--- a/LiveSplit.WatchDogs2.asl
+++ b/LiveSplit.WatchDogs2.asl
@@ -92,8 +92,7 @@ startup
 		vars.lastSplitTime = System.DateTime.Now;
 		return !isDoubleSplit;
 	};
-	vars.isNotDoubleSplit = isNotDoubleSplit;
-	
+	vars.isNotDoubleSplit = isNotDoubleSplit;	
 }
 
 init
@@ -137,10 +136,15 @@ isLoading
 		return current.loading1 > 0 || current.loading2 > 0;
 }
 
-start{
-
-	if (vars.stopwatch.ElapsedMilliseconds > 6000)
+update
+{
+    	if (vars.stopwatch.ElapsedMilliseconds > 10000)
 		vars.stopwatch.Reset();
+	if (old.LineId == 658798)
+		vars.stopwatch.Start();
+
+start
+{
 	if (current.LineId == 693964)
 		vars.stopwatch.Start();
 	if (current.LineId == 693964 && vars.stopwatch.ElapsedMilliseconds > 5066.67)
@@ -151,7 +155,7 @@ split
 {
 	if (settings["Buy Pants"] && current.followers == old.followers + 2200) // Buying Pants Finished
 		return true;
-	if(old.LineId == 658785 && current.LineId > 100000) //Walk in the Park Finished  
+	if (old.LineId == 658785 && vars.stopwatch.ElapsedMilliseconds > 600) //Walk in the Park Finished  
 		return vars.isNotDoubleSplit();
 	if (current.followers == old.followers + 46000) // Cyberdriver Finished
 		return true;

--- a/LiveSplit.WatchDogs2.asl
+++ b/LiveSplit.WatchDogs2.asl
@@ -142,6 +142,7 @@ update
 		vars.stopwatch.Reset();
 	if (old.LineId == 658798)
 		vars.stopwatch.Start();
+}
 
 start
 {

--- a/LiveSplit.WatchDogs2.asl
+++ b/LiveSplit.WatchDogs2.asl
@@ -57,7 +57,7 @@ state("WatchDogs2", "v1.011.174.6.1009368")
 	int loading1 : "Disrupt_64.dll", 0x3E69E1C;
 	int loading2 : "Disrupt_64.dll", 0x3E13B34;
 	int followers : "Disrupt_64.dll", 0x3E157F0, 0xD0, 0x40, 0xD0, 0x80, 0x38, 0x30, 0xC0;
-	int LineId: "Disrupt_64.dll", 0x3C82108, 0x288, 0x90, 0x190, 0xB8, 0x9E8;
+	int lineId : "Disrupt_64.dll", 0x3C82108, 0x288, 0x90, 0x190, 0xB8, 0x9E8;
 }
 
 state("WatchDogs2", "v1.017.189.2.1088394")
@@ -65,20 +65,21 @@ state("WatchDogs2", "v1.017.189.2.1088394")
 	int loading1 : "Disrupt_64.dll", 0x401E824;
 	int loading2 : "Disrupt_64.dll", 0x3FC34B4;
 	int followers : "Disrupt_64.dll", 0x401AC10, 0xC8, 0x8, 0x168, 0xE0, 0xC0;
-	int LineId: "Disrupt_64.dll", 0x400FA90, 0x28;
+	int lineId : "Disrupt_64.dll", 0x400FA90, 0x28;
 }
 
 startup
 {
 	settings.Add("BuyPants", false, "Split for buying pants");
 	settings.SetToolTip("BuyPants", "Splits after buying pants at the beginning of the game.");
-	
+
 	vars.stopwatch = new Stopwatch();
-	
+
 	Action<string> logDebug = (text) => {
-        	print("[Watch_Dogs 2 Autosplitter | DEBUG] "+ text);
-    		};
-   		vars.logDebug = logDebug;
+		print("[Watch_Dogs 2 Autosplitter | DEBUG] " + text);
+	};
+	vars.logDebug = logDebug;
+
 	vars.lastSplitTime = null;
 	Func<bool> isNotDoubleSplit = () => {
 		bool isDoubleSplit = false;
@@ -92,7 +93,7 @@ startup
 		vars.lastSplitTime = System.DateTime.Now;
 		return !isDoubleSplit;
 	};
-	vars.isNotDoubleSplit = isNotDoubleSplit;	
+	vars.isNotDoubleSplit = isNotDoubleSplit;
 }
 
 init
@@ -138,25 +139,25 @@ isLoading
 
 update
 {
-    	if (vars.stopwatch.ElapsedMilliseconds > 10000)
+	if (vars.stopwatch.ElapsedMilliseconds > 10000)
 		vars.stopwatch.Reset();
-	if (old.LineId == 658798)
+	if (old.lineId == 658798)
 		vars.stopwatch.Start();
 }
 
 start
 {
-	if (current.LineId == 693964)
+	if (current.lineId == 693964)
 		vars.stopwatch.Start();
-	if (current.LineId == 693964 && vars.stopwatch.ElapsedMilliseconds > 5066.67)
-		return true;	
+	if (current.lineId == 693964 && vars.stopwatch.ElapsedMilliseconds > 5066.67)
+		return true;
 }
 
 split
 {
 	if (settings["Buy Pants"] && current.followers == old.followers + 2200) // Buying Pants Finished
 		return true;
-	if (old.LineId == 658785 && vars.stopwatch.ElapsedMilliseconds > 600) //Walk in the Park Finished  
+	if (old.lineId == 658785 && vars.stopwatch.ElapsedMilliseconds > 600) // Walk in the Park Finished
 		return vars.isNotDoubleSplit();
 	if (current.followers == old.followers + 46000) // Cyberdriver Finished
 		return true;

--- a/LiveSplit.WatchDogs2.asl
+++ b/LiveSplit.WatchDogs2.asl
@@ -73,6 +73,8 @@ startup
 	settings.Add("BuyPants", false, "Split for buying pants");
 	settings.SetToolTip("BuyPants", "Splits after buying pants at the beginning of the game.");
 	
+	vars.stopwatch = new Stopwatch();
+	
 	Action<string> logDebug = (text) => {
         	print("[Watch_Dogs 2 Autosplitter | DEBUG] "+ text);
     		};


### PR DESCRIPTION
Adds a few new things. Found line ids for every string in the game because I was able to obtain decompiled strings from the WD modding community.

1. LineId pointer path is added for automatic timer starting and splitting for Walk in the Park. LineId only works if subtitles are enabled. Also not sure if it will work if the language isn't English.

2. Startup:  Added stopwatch variable because combining it with LineId for autostarting. Double split protection of 15 seconds is added to prevent splitting multiple times with LineId during Walk in the Park.  This stuff is copied from my WD1 autosplitter. Buying pants is set to false because of Walk in the Park autosplitting added. 

3. Update: Added stopwatch stuff to help with splitting for finishing Walk in the Park and to reset stopwatch. 

4. Start: Automatic timer starting stuff using LineId and stopwatch variables.

5. Split: Splitting for finishing Walk in the Park is added.