### PR TITLE
gta3: Add support for SteamStub-less Steam EXE

### DIFF
--- a/LiveSplit.GTA3-NEW.asl
+++ b/LiveSplit.GTA3-NEW.asl
@@ -15,6 +15,7 @@ startup
 {
 	// Set the autosplitter refresh rate (lower = less CPU and less accurate, higher = more CPU usage and more accurate) default: 60
 	refreshRate = 30;
+
 	
 	// List of mission memory addresses (for Steam, see below for where offsets get added).
 	vars.missionAddresses = new Dictionary<int, string> {
@@ -138,6 +139,13 @@ init
 	
 	// Detects current game version if Steam.
 	if (modules.First().ModuleMemorySize == 6197248)
+	{
+		version = "Steam";
+		vars.offset = 0;
+	}
+
+	// Detect Steam version without SteamStub
+	else if (modules.First().ModuleMemorySize == 5836800)
 	{
 		version = "Steam";
 		vars.offset = 0;

--- a/Release/LiveSplit.GTA3.asl
+++ b/Release/LiveSplit.GTA3.asl
@@ -15,6 +15,7 @@ startup
 {
 	// Set the autosplitter refresh rate (lower = less CPU and less accurate, higher = more CPU usage and more accurate) default: 60
 	refreshRate = 30;
+
 	
 	// List of mission memory addresses (for Steam, see below for where offsets get added).
 	vars.missionAddresses = new Dictionary<int, string> {
@@ -138,6 +139,13 @@ init
 	
 	// Detects current game version if Steam.
 	if (modules.First().ModuleMemorySize == 6197248)
+	{
+		version = "Steam";
+		vars.offset = 0;
+	}
+
+	// Detect Steam version without SteamStub
+	else if (modules.First().ModuleMemorySize == 5836800)
 	{
 		version = "Steam";
 		vars.offset = 0;


### PR DESCRIPTION
Because of the delisting of III/VC/SA from all digital retailers, we're now sharing ready versions of the games in the Discord (since they're basically abandonware).

The GTA III version there is the Steam version with the SteamStub DRM removed, which caused the autosplitter version detection to fail due to the EXE size change. This PR just adds a check for that version.

I've tested the main stuff and the memory addresses didn't seem to change, so should be good to merge as-is.