### PR TITLE
use asl-help to cut down on code

### DIFF
--- a/LiveSplit.IAmJesusChrist.asl
+++ b/LiveSplit.IAmJesusChrist.asl
@@ -4,66 +4,35 @@ state("Level1")
 }
 
 // I Am Jesus Christ: Prologue
-// https://steamdb.info/patchnotes/10094678/
+// https://steamdb.info/patchnotes/10094678
 state("Level1", "Patch2")
 {
-  int loading : 0xBB603D8; // 0 when not loading, above 0 when loading
+  bool loading : 0xBB603D8; // 0 when not loading, above 0 when loading
 }
 
 init
 {
-  switch (modules.First().ModuleMemorySize)
+  switch ((int)vars.Helper.GetMemorySize())
   {
-    case 212201472:
+    case 0xCA5F000:
       version = "Patch2";
       break;
-  }
-
-  // Workaround to reject the process if it doesn't match.
-  // This is needed when the "launcher" EXE and the game "EXE" are named identically.
-  // Source: https://github.com/LiveSplit/LiveSplit.ScriptableAutoSplit/issues/56
-  if (version == "") {
-    var allComponents = timer.Layout.Components;
-    // Grab the autosplitter from splits
-    if (timer.Run.AutoSplitter != null && timer.Run.AutoSplitter.Component != null) {
-      allComponents = allComponents.Append(timer.Run.AutoSplitter.Component);
-    }
-    foreach (var component in allComponents) {
-      var type = component.GetType();
-      if (type.Name == "ASLComponent") {
-        // Could also check script path, but renaming the script breaks that, and
-        // running multiple autosplitters at once is already just asking for problems
-        var script = type.GetProperty("Script").GetValue(component);
-        script.GetType().GetField(
-          "_game",
-          BindingFlags.NonPublic | BindingFlags.Instance
-        ).SetValue(script, null);
-      }
-    }
+    default:
+      vars.Helper.Game = null;
+      return;
   }
 }
 
 startup
 {
-  // Stolen some several other scripts; asks the user if they want to switch to
-  // Game Time when the script loads if needed.
-  if (timer.CurrentTimingMethod == TimingMethod.RealTime) {
-    var timingMessage = MessageBox.Show(
-      "This game uses Time without Loads (Game Time) as the main timing method.\n"+
-      "LiveSplit is currently set to show Real Time (RTA).\n"+
-      "Would you like to set the timing method to Game Time?",
-      "LiveSplit | I Am Jesus Christ",
-      MessageBoxButtons.YesNo, MessageBoxIcon.Question
-    );
-    if (timingMessage == DialogResult.Yes)
-      timer.CurrentTimingMethod = TimingMethod.GameTime;
-  }
+  Assembly.Load(File.ReadAllBytes("Components/asl-help")).CreateInstance("Basic");
+  vars.Helper.AlertLoadless();
 }
 
 isLoading
 {
   if (version != "")
-    return current.loading > 0;
+    return current.loading;
 }
 
 exit

--- a/LiveSplit.IAmJesusChrist.asl
+++ b/LiveSplit.IAmJesusChrist.asl
@@ -1,3 +1,7 @@
+// Some of this script requires the use of the "asl-help" library.
+// This will be loaded automatically if using this script from within the splits editor.
+// https://github.com/just-ero/asl-help
+
 state("Level1")
 {
   // unknown/default version


### PR DESCRIPTION
This PR introduces the use of my `asl-help` library (https://github.com/just-ero/asl-help, download [here](https://github.com/just-ero/asl-help/blob/main/lib/asl-help)) which has some of the boilerplate code built in with easier methods.

Setting `vars.Helper.Game` to `null` automatically does so for the internal `ASLScript` class, which has the same effect as the large reflection loop in `init`. The `AlertLoadless` method does the same as the message box code before it did.

If you decide to use this, you will need to add it to your entry in `LiveSplit.AutoSplitters.xml` as well.